### PR TITLE
Updated method to access rootViewController

### DIFF
--- a/ios/Classes/API/UsercentricsBannerProxy.swift
+++ b/ios/Classes/API/UsercentricsBannerProxy.swift
@@ -16,7 +16,7 @@ struct UsercentricsBannerProxy: UsercentricsBannerProxyProtocol {
     func showFirstLayer(bannerSettings: BannerSettings?,
                         layout: UsercentricsLayout,
                         completionHandler: @escaping (UsercentricsConsentUserResponse) -> Void) {
-        guard let flutterVC = UIApplication.shared.delegate?.window??.rootViewController as? FlutterViewController else { return }
+        guard let flutterVC = UIApplication.shared.windows.last?.rootViewController as? FlutterViewController else { return }
 
         UsercentricsBanner(bannerSettings: bannerSettings).showFirstLayer(hostView: flutterVC,
                                                                          layout: layout) { response in


### PR DESCRIPTION
Accessing the rootViewController using SceneDelegates inside the project is only possible this way.