### PR TITLE
Fix the issue when the FlutterViewController is not the rootViewController

### DIFF
--- a/ios/Classes/API/UsercentricsBannerProxy.swift
+++ b/ios/Classes/API/UsercentricsBannerProxy.swift
@@ -41,9 +41,9 @@ struct UsercentricsBannerProxy: UsercentricsBannerProxyProtocol {
                 .connectedScenes
                 .compactMap { $0 as? UIWindowScene }
                 .flatMap { $0.windows }
-                .first { $0.isKeyWindow }
+                .first { $1.isKeyWindow }
         } else {
-            window = UIApplication.shared.windows.first { $0.isKeyWindow }
+            window = UIApplication.shared.windows.first { $1.isKeyWindow }
         }
         return window?.rootViewController as? FlutterViewController
     }

--- a/ios/Classes/API/UsercentricsBannerProxy.swift
+++ b/ios/Classes/API/UsercentricsBannerProxy.swift
@@ -41,11 +41,12 @@ struct UsercentricsBannerProxy: UsercentricsBannerProxyProtocol {
                 .connectedScenes
                 .compactMap { $0 as? UIWindowScene }
                 .flatMap { $0.windows }
-                .first { $1.isKeyWindow }
+                .first { $0.isKeyWindow }
         } else {
-            window = UIApplication.shared.windows.first { $1.isKeyWindow }
+            window = UIApplication.shared.windows.first { $0.isKeyWindow }
         }
-        return window?.rootViewController as? FlutterViewController
+        return window?.rootViewController?.presentedViewController as? FlutterViewController
+
     }
 
 }


### PR DESCRIPTION
Recently I was working on an animated splash screen for our flutter app at flaconi, and for this purpose, we have to create a launchScreenViewController and make it the rootViewController and run the animation, when the animation gets completed we are presenting the flutterViewController in the iOS project. 

In this scenario, Usercentrics native iOS dialogs stop working  because of the following code 

` return window?.rootViewController as? FlutterViewController` assuming that FlutterViewController is always the rootViewController. 

I tried to fix that on my fork by using the `presentedViewController` instead and it was working fine.

This PR is to fix this issue.

Let me know in case you have any questions. 