### PR TITLE
Allow CCPA opted out flag to be nullable

### DIFF
--- a/lib/src/internal/platform/method_channel_usercentrics.dart
+++ b/lib/src/internal/platform/method_channel_usercentrics.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:usercentrics_sdk/src/internal/bridge/bridge.dart';
-import 'package:usercentrics_sdk/src/model/exception.dart';
 import 'package:usercentrics_sdk/src/model/model.dart';
 import 'package:usercentrics_sdk/src/platform/usercentrics_platform.dart';
 

--- a/lib/src/internal/platform/method_channel_usercentrics.dart
+++ b/lib/src/internal/platform/method_channel_usercentrics.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:usercentrics_sdk/src/internal/bridge/bridge.dart';
+import 'package:usercentrics_sdk/src/model/exception.dart';
 import 'package:usercentrics_sdk/src/model/model.dart';
 import 'package:usercentrics_sdk/src/platform/usercentrics_platform.dart';
 
@@ -327,23 +328,4 @@ class MethodChannelUsercentrics extends UsercentricsPlatform {
     await _ensureIsReady();
     return await getAdditionalConsentModeData.invoke(channel: _channel);
   }
-}
-
-class FailedInitializationException implements Exception {
-  final String message;
-
-  const FailedInitializationException(this.message);
-
-  @override
-  String toString() => "$FailedInitializationException: $message";
-}
-
-class NotInitializedException implements Exception {
-  static const message =
-      "Usercentrics was not initialized, please ensure that you invoke 'Usercentrics.initialize()' before you start using it";
-
-  const NotInitializedException();
-
-  @override
-  String toString() => "$NotInitializedException: $message";
 }

--- a/lib/src/model/ccpa_data.dart
+++ b/lib/src/model/ccpa_data.dart
@@ -14,8 +14,10 @@ class CCPAData {
   /// True if the notice was given. False if not.
   final bool? noticeGiven;
 
-  /// True if the user opted out the consents, so the user denies the services. False if not, so the user accepts the services.
-  final bool optedOut;
+  /// True if the user opted out the consents, so the user denies the services.
+  /// False if not, so the user accepts the services.
+  /// Null if the user did not interact with the CMP, so the user accepts the services implicitly.
+  final bool? optedOut;
 
   /// Limited Service Provider Agreement Covered Transaction.
   final bool? lspact;

--- a/lib/src/model/exception.dart
+++ b/lib/src/model/exception.dart
@@ -1,0 +1,18 @@
+class FailedInitializationException implements Exception {
+  final String message;
+
+  const FailedInitializationException(this.message);
+
+  @override
+  String toString() => "$FailedInitializationException: $message";
+}
+
+class NotInitializedException implements Exception {
+  static const message =
+      "Usercentrics was not initialized, please ensure that you invoke 'Usercentrics.initialize()' before you start using it";
+
+  const NotInitializedException();
+
+  @override
+  String toString() => "$NotInitializedException: $message";
+}

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -9,6 +9,7 @@ export 'cmp_data.dart';
 export 'consent_disclosure.dart';
 export 'consent_type.dart';
 export 'customization.dart';
+export 'exception.dart';
 export 'first_layer_style_settings.dart';
 export 'font.dart';
 export 'general_style_settings.dart';


### PR DESCRIPTION
I encounter an exception within CCPA regions when there is no user interaction with the CMP. It appears that optedOut is nullable on the native side, but this is not the case on the Flutter side.

Furthermore, I have included initialization-related exceptions in model.dart to allow for explicit handling.
