### PR TITLE
Fix CCPA data serialization

### DIFF
--- a/lib/src/internal/platform/method_channel_usercentrics.dart
+++ b/lib/src/internal/platform/method_channel_usercentrics.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:usercentrics_sdk/src/internal/bridge/bridge.dart';
-import 'package:usercentrics_sdk/src/model/exception.dart';
 import 'package:usercentrics_sdk/src/model/model.dart';
 import 'package:usercentrics_sdk/src/platform/usercentrics_platform.dart';
 

--- a/lib/src/internal/platform/method_channel_usercentrics.dart
+++ b/lib/src/internal/platform/method_channel_usercentrics.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:usercentrics_sdk/src/internal/bridge/bridge.dart';
+import 'package:usercentrics_sdk/src/model/exception.dart';
 import 'package:usercentrics_sdk/src/model/model.dart';
 import 'package:usercentrics_sdk/src/platform/usercentrics_platform.dart';
 
@@ -32,8 +33,7 @@ class MethodChannelUsercentrics extends UsercentricsPlatform {
       this.getABTestingVariantBridge = const MethodChannelGetABTestingVariant(),
       this.setABTestingVariantBridge = const MethodChannelSetABTestingVariant(),
       this.trackBridge = const MethodChannelTrack(),
-      this.getAdditionalConsentModeData =
-          const MethodChannelGetAdditionalConsentModeData()});
+      this.getAdditionalConsentModeData = const MethodChannelGetAdditionalConsentModeData()});
 
   static const MethodChannel _channel = MethodChannel('usercentrics');
 
@@ -108,8 +108,7 @@ class MethodChannelUsercentrics extends UsercentricsPlatform {
   }
 
   @override
-  Future<UsercentricsReadyStatus> get status =>
-      isReadyBridge.invoke(channel: _channel);
+  Future<UsercentricsReadyStatus> get status => isReadyBridge.invoke(channel: _channel);
 
   @override
   Future<UsercentricsConsentUserResponse?> showFirstLayer({
@@ -150,8 +149,7 @@ class MethodChannelUsercentrics extends UsercentricsPlatform {
     required String controllerId,
   }) async {
     await _ensureIsReady();
-    return await restoreUserSessionBridge.invoke(
-        channel: _channel, controllerId: controllerId);
+    return await restoreUserSessionBridge.invoke(channel: _channel, controllerId: controllerId);
   }
 
   @override
@@ -299,8 +297,7 @@ class MethodChannelUsercentrics extends UsercentricsPlatform {
     required String variant,
   }) async {
     await _ensureIsReady();
-    return await setABTestingVariantBridge.invoke(
-        channel: _channel, variant: variant);
+    return await setABTestingVariantBridge.invoke(channel: _channel, variant: variant);
   }
 
   Future<void> _ensureIsReady() async {
@@ -327,23 +324,4 @@ class MethodChannelUsercentrics extends UsercentricsPlatform {
     await _ensureIsReady();
     return await getAdditionalConsentModeData.invoke(channel: _channel);
   }
-}
-
-class FailedInitializationException implements Exception {
-  final String message;
-
-  const FailedInitializationException(this.message);
-
-  @override
-  String toString() => "$FailedInitializationException: $message";
-}
-
-class NotInitializedException implements Exception {
-  static const message =
-      "Usercentrics was not initialized, please ensure that you invoke 'Usercentrics.initialize()' before you start using it";
-
-  const NotInitializedException();
-
-  @override
-  String toString() => "$NotInitializedException: $message";
 }

--- a/lib/src/model/ccpa_data.dart
+++ b/lib/src/model/ccpa_data.dart
@@ -15,7 +15,7 @@ class CCPAData {
   final bool? noticeGiven;
 
   /// True if the user opted out the consents, so the user denies the services. False if not, so the user accepts the services.
-  final bool optedOut;
+  final bool? optedOut;
 
   /// Limited Service Provider Agreement Covered Transaction.
   final bool? lspact;

--- a/lib/src/model/ccpa_data.dart
+++ b/lib/src/model/ccpa_data.dart
@@ -14,7 +14,9 @@ class CCPAData {
   /// True if the notice was given. False if not.
   final bool? noticeGiven;
 
-  /// True if the user opted out the consents, so the user denies the services. False if not, so the user accepts the services.
+  /// True if the user opted out the consents, so the user denies the services.
+  /// False if not, so the user accepts the services. Null if the user did not
+  /// interact with the CMP, so the user accepts the services implicitly.
   final bool? optedOut;
 
   /// Limited Service Provider Agreement Covered Transaction.
@@ -36,11 +38,7 @@ class CCPAData {
 
   @override
   int get hashCode =>
-      version.hashCode +
-      noticeGiven.hashCode +
-      optedOut.hashCode +
-      lspact.hashCode +
-      uspString.hashCode;
+      version.hashCode + noticeGiven.hashCode + optedOut.hashCode + lspact.hashCode + uspString.hashCode;
 
   @override
   String toString() =>

--- a/lib/src/model/exception.dart
+++ b/lib/src/model/exception.dart
@@ -1,0 +1,18 @@
+class FailedInitializationException implements Exception {
+  final String message;
+
+  const FailedInitializationException(this.message);
+
+  @override
+  String toString() => "$FailedInitializationException: $message";
+}
+
+class NotInitializedException implements Exception {
+  static const message =
+      "Usercentrics was not initialized, please ensure that you invoke 'Usercentrics.initialize()' before you start using it";
+
+  const NotInitializedException();
+
+  @override
+  String toString() => "$NotInitializedException: $message";
+}

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -9,6 +9,7 @@ export 'cmp_data.dart';
 export 'consent_disclosure.dart';
 export 'consent_type.dart';
 export 'customization.dart';
+export 'exception.dart';
 export 'first_layer_style_settings.dart';
 export 'font.dart';
 export 'general_style_settings.dart';


### PR DESCRIPTION
This PR fixes two issues that we had to fix when releasing our UserCentrics integration for our app to production. 

The first issue prevented an start of our app when initializing the UserCentrics SDK and get the CCPA consent information in CCPA regions. It seems that the `optedOut` Flag of the `CCPAData` is nullable on the Native iOS and Adnroid SDKs, but was modeled as non-nullable boolean on the Dart side, which resulted in a fatal exception upon deserialization of the CCPA data received from the native side. The null value means that the user has not explicitly given or withdrawn the consent in CCPA regions.

The other change in the PR makes the two exceptions `FailedInitializationException` and `NotInitializedException` publicly available, because we had to programmatically react on exceptions of these type and did not want to to parse the error message of the exceptions, which might lead to unhandled exceptions in the future, when the error message provided by the exception might change.

This PR replaces pull request #81. It would be good if the change could merged bak to the main repository soon, so we can switch back to your repository and do not have to maintain our own fork.