### PR TITLE
Updates Ci Configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -41,7 +41,7 @@ jobs:
 
   pub-dry-run:
     name: Publish Dry Run
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -54,7 +54,7 @@ jobs:
   test-flutter:
     name: Test Flutter
     needs: [ lint, format, pub-dry-run ]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -71,7 +71,7 @@ jobs:
   test-android:
     name: Test Android
     needs: [ lint, format, pub-dry-run ]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
     env:
@@ -131,7 +131,7 @@ jobs:
   build-android:
     name: Build Android Example
     needs: [ lint, format, pub-dry-run ]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Cache Gradle
         id: cache-gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ./example/android/ci-cache/gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -41,7 +41,7 @@ jobs:
 
   pub-dry-run:
     name: Publish Dry Run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -54,7 +54,7 @@ jobs:
   test-flutter:
     name: Test Flutter
     needs: [ lint, format, pub-dry-run ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 
@@ -71,7 +71,7 @@ jobs:
   test-android:
     name: Test Android
     needs: [ lint, format, pub-dry-run ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
     env:
@@ -131,7 +131,7 @@ jobs:
   build-android:
     name: Build Android Example
     needs: [ lint, format, pub-dry-run ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ghcr.io/cirruslabs/flutter:3.13.5
     timeout-minutes: 20
 


### PR DESCRIPTION
In 2025, ubuntu-latest will become 24.04 version -> https://github.com/actions/runner-images/issues/10636

In order to validate that everything would still work, I manually changed from ubuntu-latest to ubuntu-24.04 and verified that ci steps would still run successfully. After that, reverted to ubuntu-latest again and only updated the actions/cache to the most recent.


<img width="1345" alt="Screenshot 2024-12-16 at 16 02 58" src="https://github.com/user-attachments/assets/5e44f72b-bfcc-4943-a37d-87006dae5511" />
