### PR TITLE
Release: 2.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 [Release Notes](https://docs.usercentrics.com/cmp_in_app_sdk/latest/about/history/)
+### 2.26.1 – Apr 07, 2026
+## Features
+* Added support for US National (GPP) privacy framework
+* Extended GPP API to Flutter, React Native and Unity bridges
+* Exposed DPS metadata via new `getDpsMetadata()` API
+* TCF resurfacing period now configurable via Admin UI (1–13 months)
+## Fixes
+* Fixed TCF resurfacing period logic
+* Fixed stored information not shown on DPS details
+* Fixed TCF maintain legitimate interest logic on Deny All
+
 ### 2.25.1 – Mar 02, 2026
 ## Improvement
 * Patch with security fixes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-def usercentrics_version = "2.25.1"
+def usercentrics_version = "2.26.1"
 
 group 'com.usercentrics.sdk.flutter'
 version usercentrics_version

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.25.1"
+    version: "2.26.1"
   vector_math:
     dependency: transitive
     description:

--- a/ios/usercentrics_sdk.podspec
+++ b/ios/usercentrics_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'usercentrics_sdk'
-  s.version = '2.25.1'
+  s.version = '2.26.1'
   s.summary          = 'Usercentrics Flutter SDK.'
   s.description      = <<-DESC
   Usercentrics Flutter SDK.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/Usercentrics/flutter-sdk/
 #  [X] android/build.gradle
 #  [X] ios/usercentrics_sdk.podspec + pod install/update
 #  [X] CHANGELOG.md
-version: 2.25.1
+version: 2.26.1
 
 environment:
   sdk: ">=2.17.1 <4.0.0"


### PR DESCRIPTION
## Release 2.26.1

### Features
* Added support for US National (GPP) privacy framework
* Extended GPP API to Flutter, React Native and Unity bridges
* Exposed DPS metadata via new `getDpsMetadata()` API
* TCF resurfacing period now configurable via Admin UI (1–13 months)

### Fixes
* Fixed TCF resurfacing period logic
* Fixed stored information not shown on DPS details
* Fixed TCF maintain legitimate interest logic on Deny All