### PR TITLE
fix(MSDK-3663): wire consentMediation flag in iOS InitializeOptionsSerializer

### DIFF
--- a/ios/Classes/Serializer/InitializeOptionsSerializer.swift
+++ b/ios/Classes/Serializer/InitializeOptionsSerializer.swift
@@ -44,6 +44,10 @@ extension UsercentricsOptions {
             options.initTimeoutMillis = Int64(initTimeoutMillis)
         }
 
+        if let consentMediation = dict["consentMediation"] as? Bool {
+            options.consentMediation = consentMediation
+        }
+
         return options
     }
     


### PR DESCRIPTION
Description:
                                                                                                                                                                                                                               
  ## Summary                                                                                                                                                                                                                              
  - `consentMediation` was not being deserialized in `InitializeOptionsSerializer.swift`,
    causing the flag to always default to `false` on iOS regardless of what was passed                                                                                                                                         
    from the Dart layer — meaning mediation SDKs were never invoked on iOS.                                                                                                                                                    
  - Android was unaffected as its serializer already handled this field correctly.                                                                                                                                             
  - Added `mavenLocal()` to the Android bridge plugin repositories to support local                                                                                                                                            
    `mobile-sdk` builds during development.