### PR TITLE
[MSDK-3955] Expose mandatoryLabel in TCF2Settings Flutter bridge for PUR compliance

### DIFF
--- a/android/src/main/kotlin/com/usercentrics/sdk/flutter/serializer/CMPDataSerializer.kt
+++ b/android/src/main/kotlin/com/usercentrics/sdk/flutter/serializer/CMPDataSerializer.kt
@@ -227,7 +227,8 @@ private fun TCF2Settings.serialize(): Any {
         "changedPurposes" to changedPurposes?.serialize(),
         "acmV2Enabled" to acmV2Enabled,
         "selectedATPIds" to selectedATPIds,
-        "consentOrPay" to consentOrPay?.serialize()
+        "consentOrPay" to consentOrPay?.serialize(),
+        "mandatoryLabel" to mandatoryLabel
     )
 }
 

--- a/ios/Classes/Serializer/CMPDataSerializer.swift
+++ b/ios/Classes/Serializer/CMPDataSerializer.swift
@@ -217,7 +217,8 @@ extension TCF2Settings {
             "changedPurposes": self.changedPurposes?.serialize() as Any,
             "acmV2Enabled" : self.acmV2Enabled,
             "selectedATPIds" : self.selectedATPIds,
-            "consentOrPay": self.consentOrPay?.serialize() as Any
+            "consentOrPay": self.consentOrPay?.serialize() as Any,
+            "mandatoryLabel": self.mandatoryLabel
         ]
     }
 }

--- a/lib/src/internal/serializer/tcf2_settings_serializer.dart
+++ b/lib/src/internal/serializer/tcf2_settings_serializer.dart
@@ -70,7 +70,8 @@ class TCF2SettingsSerializer {
         acmV2Enabled: value['acmV2Enabled'] ?? false,
         selectedATPIds: value['selectedATPIds']?.cast<int>() ?? [],
         consentOrPay: TCF2ConsentOrPaySettingsSerializer.deserialize(
-            value['consentOrPay']));
+            value['consentOrPay']),
+        mandatoryLabel: value['mandatoryLabel'] ?? "Mandatory");
   }
 }
 

--- a/lib/src/model/tcf2_settings.dart
+++ b/lib/src/model/tcf2_settings.dart
@@ -61,7 +61,8 @@ class TCF2Settings {
       required this.changedPurposes,
       required this.acmV2Enabled,
       required this.selectedATPIds,
-      this.consentOrPay});
+      this.consentOrPay,
+      this.mandatoryLabel = "Mandatory"});
 
   final String firstLayerTitle;
   final String secondLayerTitle;
@@ -123,6 +124,7 @@ class TCF2Settings {
   final bool acmV2Enabled;
   final List<int> selectedATPIds;
   final TCF2ConsentOrPaySettings? consentOrPay;
+  final String mandatoryLabel;
 
   @override
   bool operator ==(Object other) =>
@@ -192,7 +194,8 @@ class TCF2Settings {
           changedPurposes == other.changedPurposes &&
           acmV2Enabled == other.acmV2Enabled &&
           listEquals(selectedATPIds, other.selectedATPIds) &&
-          consentOrPay == other.consentOrPay;
+          consentOrPay == other.consentOrPay &&
+          mandatoryLabel == other.mandatoryLabel;
 
   @override
   int get hashCode =>
@@ -255,7 +258,8 @@ class TCF2Settings {
       changedPurposes.hashCode +
       acmV2Enabled.hashCode +
       selectedATPIds.hashCode +
-      consentOrPay.hashCode;
+      consentOrPay.hashCode +
+      mandatoryLabel.hashCode;
 
   @override
   String toString() => "$TCF2Settings($hashCode)";


### PR DESCRIPTION
## Summary

- Adds `mandatoryLabel: String` (default: `"Mandatory"`) to `TCF2Settings` in the Flutter bridge — missed in the original PR #171 that exposed `consentOrPay`
- Both fields were added to the mobile-sdk `TCF2Settings` in 2.27.0; only `consentOrPay` was bridged

## Changes

- `lib/src/model/tcf2_settings.dart` — added field declaration, constructor param, `==`, `hashCode`
- `lib/src/internal/serializer/tcf2_settings_serializer.dart` — deserialize from `value['mandatoryLabel']` with `"Mandatory"` fallback
- `android/.../CMPDataSerializer.kt` — serialize `mandatoryLabel`
- `ios/Classes/Serializer/CMPDataSerializer.swift` — serialize `mandatoryLabel`

## Why it matters

Flutter developers building a custom TCF second layer via `getCmpData()` need `mandatoryLabel` to render the mandatory badge on purposes/special features that have no toggle under the ConsentOrPay flow. Without it they would have to hardcode `"Mandatory"`, which breaks when the value is overridden via the `app_PUR_MANDATORY_LABEL_TEXT` translation key.

## Test plan

- [x] All 64 Flutter unit tests pass (`flutter test`)