### PR TITLE
feat(MSDK-4088): Support PL-5714 new COP restriction fields across Dart, Android and iOS

### DIFF
--- a/android/src/main/kotlin/com/usercentrics/sdk/flutter/serializer/CMPDataSerializer.kt
+++ b/android/src/main/kotlin/com/usercentrics/sdk/flutter/serializer/CMPDataSerializer.kt
@@ -8,6 +8,7 @@ import com.usercentrics.sdk.v2.settings.data.CustomizationFont
 import com.usercentrics.sdk.v2.settings.data.FirstLayer
 import com.usercentrics.sdk.v2.settings.data.PublishedApp
 import com.usercentrics.sdk.v2.settings.data.SecondLayer
+import com.usercentrics.sdk.v2.settings.data.ConsentOrPayRestriction
 import com.usercentrics.sdk.v2.settings.data.ConsentOrPaySettings
 import com.usercentrics.sdk.v2.settings.data.TCF2ChangedPurposes
 import com.usercentrics.sdk.v2.settings.data.TCF2Settings
@@ -228,7 +229,8 @@ private fun TCF2Settings.serialize(): Any {
         "acmV2Enabled" to acmV2Enabled,
         "selectedATPIds" to selectedATPIds,
         "consentOrPay" to consentOrPay?.serialize(),
-        "mandatoryLabel" to mandatoryLabel
+        "mandatoryLabel" to mandatoryLabel,
+        "specialFeaturesConsentOrPay" to specialFeaturesConsentOrPay?.map { it.serialize() },
     )
 }
 
@@ -428,6 +430,12 @@ private fun TCF2ChangedPurposes?.serialize(): Any? {
     }
     return mapOf(
         "purposes" to purposes,
-        "legIntPurposes" to legIntPurposes
+        "legIntPurposes" to legIntPurposes,
+        "consentOrPay" to consentOrPay?.map { it.serialize() },
     )
 }
+
+private fun ConsentOrPayRestriction.serialize(): Map<String, Any?> = mapOf(
+    "id" to id,
+    "value" to value,
+)

--- a/ios/Classes/Serializer/CMPDataSerializer.swift
+++ b/ios/Classes/Serializer/CMPDataSerializer.swift
@@ -218,7 +218,8 @@ extension TCF2Settings {
             "acmV2Enabled" : self.acmV2Enabled,
             "selectedATPIds" : self.selectedATPIds,
             "consentOrPay": self.consentOrPay?.serialize() as Any,
-            "mandatoryLabel": self.mandatoryLabel
+            "mandatoryLabel": self.mandatoryLabel,
+            "specialFeaturesConsentOrPay": self.specialFeaturesConsentOrPay?.map { $0.serialize() } as Any,
         ]
     }
 }
@@ -409,7 +410,17 @@ extension TCF2ChangedPurposes {
     func serialize() -> Any {
         return [
             "purposes": purposes,
-            "legIntPurposes": legIntPurposes
+            "legIntPurposes": legIntPurposes,
+            "consentOrPay": consentOrPay?.map { $0.serialize() } as Any,
+        ]
+    }
+}
+
+extension ConsentOrPayRestriction {
+    func serialize() -> [String: Any] {
+        return [
+            "id": self.id,
+            "value": self.value,
         ]
     }
 }

--- a/lib/src/internal/serializer/tcf2_settings_serializer.dart
+++ b/lib/src/internal/serializer/tcf2_settings_serializer.dart
@@ -71,7 +71,10 @@ class TCF2SettingsSerializer {
         selectedATPIds: value['selectedATPIds']?.cast<int>() ?? [],
         consentOrPay: TCF2ConsentOrPaySettingsSerializer.deserialize(
             value['consentOrPay']),
-        mandatoryLabel: value['mandatoryLabel'] ?? "Mandatory");
+        mandatoryLabel: value['mandatoryLabel'] ?? "Mandatory",
+        specialFeaturesConsentOrPay:
+            ConsentOrPayRestrictionSerializer.deserializeList(
+                value['specialFeaturesConsentOrPay']));
   }
 }
 
@@ -107,7 +110,19 @@ class TCF2ChangedPurposesSerializer {
   static TCF2ChangedPurposes deserialize(value) {
     return TCF2ChangedPurposes(
         purposes: value['purposes']?.cast<int>() ?? [],
-        legIntPurposes: value['legIntPurposes']?.cast<int>() ?? []);
+        legIntPurposes: value['legIntPurposes']?.cast<int>() ?? [],
+        consentOrPay: ConsentOrPayRestrictionSerializer.deserializeList(
+            value['consentOrPay']));
+  }
+}
+
+class ConsentOrPayRestrictionSerializer {
+  static List<ConsentOrPayRestriction>? deserializeList(value) {
+    if (value == null) return null;
+    return (value as List)
+        .map((e) => ConsentOrPayRestriction(
+            id: e['id'] as int, value: e['value'] as String))
+        .toList();
   }
 }
 

--- a/lib/src/model/tcf2_settings.dart
+++ b/lib/src/model/tcf2_settings.dart
@@ -62,7 +62,8 @@ class TCF2Settings {
       required this.acmV2Enabled,
       required this.selectedATPIds,
       this.consentOrPay,
-      this.mandatoryLabel = "Mandatory"});
+      this.mandatoryLabel = "Mandatory",
+      this.specialFeaturesConsentOrPay});
 
   final String firstLayerTitle;
   final String secondLayerTitle;
@@ -125,6 +126,7 @@ class TCF2Settings {
   final List<int> selectedATPIds;
   final TCF2ConsentOrPaySettings? consentOrPay;
   final String mandatoryLabel;
+  final List<ConsentOrPayRestriction>? specialFeaturesConsentOrPay;
 
   @override
   bool operator ==(Object other) =>
@@ -271,10 +273,13 @@ enum TCF2Scope { global, service }
 
 class TCF2ChangedPurposes {
   const TCF2ChangedPurposes(
-      {required this.purposes, required this.legIntPurposes});
+      {required this.purposes,
+      required this.legIntPurposes,
+      this.consentOrPay});
 
   final List<int> purposes;
   final List<int> legIntPurposes;
+  final List<ConsentOrPayRestriction>? consentOrPay;
 
   @override
   bool operator ==(Object other) =>
@@ -282,10 +287,32 @@ class TCF2ChangedPurposes {
       other is TCF2ChangedPurposes &&
           runtimeType == other.runtimeType &&
           listEquals(purposes, other.purposes) &&
-          listEquals(legIntPurposes, other.legIntPurposes);
+          listEquals(legIntPurposes, other.legIntPurposes) &&
+          listEquals(consentOrPay, other.consentOrPay);
 
   @override
-  int get hashCode => purposes.hashCode ^ legIntPurposes.hashCode;
+  int get hashCode =>
+      purposes.hashCode ^ legIntPurposes.hashCode ^ consentOrPay.hashCode;
+}
+
+class ConsentOrPayRestriction {
+  const ConsentOrPayRestriction({required this.id, required this.value});
+
+  final int id;
+  final String value;
+
+  bool isFlexible() => value.toUpperCase() == 'FLEXIBLE';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConsentOrPayRestriction &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          value == other.value;
+
+  @override
+  int get hashCode => id.hashCode ^ value.hashCode;
 }
 
 class TCF2ConsentOrPaySettings {


### PR DESCRIPTION
## Summary

Adds support for the new PL-5714 JSON schema fields across all bridge layers.

**New class:** `ConsentOrPayRestriction` — `{id: int, value: 'FLEXIBLE'|'MANDATORY'}` with `isFlexible()` helper

**Updated:** `TCF2ChangedPurposes` — new `consentOrPay?: List<ConsentOrPayRestriction>` field
**Updated:** `TCF2Settings` — new `specialFeaturesConsentOrPay?: List<ConsentOrPayRestriction>` field

Both Android and iOS bridges serialize the new fields. Dart serializer deserializes both. Old `publisherRestrictions` and `specialFeatures` maps are kept for backwards compatibility.

Part of the PUR model fix tracked in [MSDK-4088](https://usercentrics.atlassian.net/browse/MSDK-4088). Native SDK changes are in [mobile-sdk PR #2401](https://bitbucket.org/usercentricscode/mobile-sdk/pull-requests/2401).

## Test plan

- [ ] Dart: `ConsentOrPayRestriction` exported correctly, new fields present on `TCF2Settings` and `TCF2ChangedPurposes`
- [ ] Android: `CMPDataSerializer` serializes `specialFeaturesConsentOrPay` and `changedPurposes.consentOrPay`
- [ ] iOS: `CMPDataSerializer` serializes both new fields
- [ ] `dart analyze` passes — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)